### PR TITLE
feat(engine): explain "Identifier expected" error

### DIFF
--- a/packages/engine/errors/1003.md
+++ b/packages/engine/errors/1003.md
@@ -1,0 +1,6 @@
+---
+original: "Identifier expected."
+excerpt: "Your code doesn't comply with the syntax rules of the TypeScript language"
+---
+
+This means that your syntax is wrong and simply the compiler can't tokenize your code properly.


### PR DESCRIPTION
Explain error `1003` about "Identifier expected."